### PR TITLE
Bump spire Helm Chart version from 0.17.3 to 0.17.4

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -3,7 +3,7 @@ name: spire
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.17.3
+version: 0.17.4
 appVersion: "1.8.5"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/eitco/helm-charts/tree/main/charts/spire


### PR DESCRIPTION
* 702dc29 Merge branch 'main' of github.com:eitco/helm-charts-hardened
* 3285a31 fixing intendation & double mapping