### PR TITLE
implementing auto-mount of kubeconfigs into spire-server

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -3,7 +3,7 @@ name: spire
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.17.6
+version: 0.17.7
 appVersion: "1.8.5"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/eitco/helm-charts/tree/main/charts/spire

--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -87,22 +87,22 @@ plugins:
           - {{ .name }}:
               service_account_allow_list: 
                 - {{ .serviceAccountAllowList | join ", " }}
-              kube_config_file: {{ .kubeconfig }}
+              kube_config_file: {{ printf "/run/spire/kubeconfigs/%s" .kubeconfig }}
               {{- with .audience }}
               audience: 
-                {{- range .audience}}
+                {{- range . }}
                   - {{ . | quote }}
                 {{- end }}
               {{- end }}
               {{- with .allowed_node_label_keys }}
               allowed_node_label_keys: 
-                {{- range .allowed_node_label_keys}}
+                {{- range . }}
                   - {{ . | quote }}
                 {{- end }}
               {{- end }}
               {{- with .allowed_pod_label_keys }}
               allowed_pod_label_keys: 
-                {{- range .allowed_pod_label_keys}}
+                {{- range . }}
                   - {{ . | quote }}
                 {{- end }}
               {{- end }}

--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -186,6 +186,12 @@ spec:
             {{- if gt (len .Values.extraVolumeMounts) 0 }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
+            {{- with .Values.nodeAttestor.k8sPsat.remoteClusters }}
+            {{- range . }}
+            - name: {{ printf "%s-kubeconfig" .name }}
+              mountPath: {{ printf "/run/spire/kubeconfigs" }}
+            {{- end }}
+            {{- end }}
         {{- if eq (.Values.controllerManager.enabled | toString) "true" }}
         - name: spire-controller-manager
           securityContext:
@@ -396,6 +402,14 @@ spec:
         {{- end }}
         {{- end -}}
         {{- end -}}
+        {{- with .Values.nodeAttestor.k8sPsat.remoteClusters }}
+        {{- range . }}
+        - name: {{ printf "%s-kubeconfig" .name }}
+          secret:
+            defaultMode: 256
+            secretName: {{ printf "%s-kubeconfig" .name }}
+        {{- end }}
+        {{- end }}
   {{- if eq .Values.persistence.type "pvc" }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -604,12 +604,13 @@ nodeAttestor:
     ## @param nodeAttestor.k8sPsat.remoteClusters [array] Add external clusters that should be managed by this spire-server instance
     ## This is required if you want to manage multiple remote clusters within one centralized spire-server
     ## See https://github.com/spiffe/spire/blob/main/doc/plugin_server_nodeattestor_k8s_psat.md for more informations
+    ## The kubeconfig will be mounted at /run/spire/kubeconfigs within the spire-server statefulset
     # remoteClusters:
     #  - name: remoteCluster1
     #    serviceAccountAllowList:
     #      - ns:sa1
     #      - ns:sa2
-    #    kubeconfig: /run/spire/kubeconfigs/remoteCluster1
+    #    kubeconfig: remoteCluster1
     #    audience:
     #      - spire-server
     #    allowed_node_label_keys: []
@@ -631,7 +632,7 @@ nodeAttestor:
     #    serviceAccountAllowList:
     #      - ns:sa3
     #      - ns:sa4
-    #    kubeconfig: /run/spire/kubeconfigs/remoteCluster2
+    #    kubeconfig: remoteCluster2
     #    audience:
     #      - spire-server
     #    allowed_node_label_keys: []


### PR DESCRIPTION
implementing auto-mount of kubeconfigs into spire-server statefulset when remoteClusters is used